### PR TITLE
Add pagination support for Sentry endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/peterhellberg/link v1.2.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -273,6 +273,8 @@ github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DV
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/peterhellberg/link v1.2.0 h1:UA5pg3Gp/E0F2WdX7GERiNrPQrM1K6CVJUUWfHa4t6c=
+github.com/peterhellberg/link v1.2.0/go.mod h1:gYfAh+oJgQu2SrZHg5hROVRQe1ICoK0/HHJTcE0edxc=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/pierrec/lz4/v4 v4.1.8 h1:ieHkV+i2BRzngO4Wd/3HGowuZStgq6QkPsD1eolNAO4=

--- a/pkg/plugin/handlers_healthcheck.go
+++ b/pkg/plugin/handlers_healthcheck.go
@@ -20,7 +20,7 @@ func (ds *SentryDatasource) CheckHealth(ctx context.Context, req *backend.CheckH
 }
 
 func CheckHealth(sentryClient sentry.SentryClient) (*backend.CheckHealthResult, error) {
-	projects, err := sentryClient.GetProjects(sentryClient.OrgSlug)
+	projects, err := sentryClient.GetProjects(sentryClient.OrgSlug, false)
 	if err != nil {
 		errorMessage := err.Error()
 		return &backend.CheckHealthResult{

--- a/pkg/plugin/handlers_resources.go
+++ b/pkg/plugin/handlers_resources.go
@@ -33,7 +33,7 @@ func GetProjectsHandler(client *sentry.SentryClient) http.HandlerFunc {
 			http.Error(rw, "invalid orgSlug", http.StatusBadRequest)
 			return
 		}
-		orgs, err := client.GetProjects(orgSlug)
+		orgs, err := client.GetAllProjects(orgSlug)
 		writeResponse(orgs, err, rw)
 	}
 }

--- a/pkg/plugin/handlers_resources.go
+++ b/pkg/plugin/handlers_resources.go
@@ -33,7 +33,7 @@ func GetProjectsHandler(client *sentry.SentryClient) http.HandlerFunc {
 			http.Error(rw, "invalid orgSlug", http.StatusBadRequest)
 			return
 		}
-		orgs, err := client.GetAllProjects(orgSlug)
+		orgs, err := client.GetProjects(orgSlug, true)
 		writeResponse(orgs, err, rw)
 	}
 }

--- a/pkg/sentry/projects.go
+++ b/pkg/sentry/projects.go
@@ -26,6 +26,7 @@ type SentryProject struct {
 	} `json:"teams"`
 }
 
+// fetch first 100 projects
 func (sc *SentryClient) GetProjects(organizationSlug string) ([]SentryProject, error) {
 	out := []SentryProject{}
 	if organizationSlug == "" {
@@ -33,6 +34,25 @@ func (sc *SentryClient) GetProjects(organizationSlug string) ([]SentryProject, e
 	}
 	err := sc.Fetch("/api/0/organizations/"+organizationSlug+"/projects/", &out)
 	return out, err
+}
+
+// Fetch all projects, checking if a link for the next page is specified in the headers
+func (sc *SentryClient) GetAllProjects(organizationSlug string) ([]SentryProject, error) {
+	allProjects := []SentryProject{}
+	url := "/api/0/organizations/" + organizationSlug + "/projects/"
+
+	for (url != "") {
+		projects := []SentryProject{}
+		nextURL, err := sc.FetchWithPagination(url, &projects)
+		if err != nil {
+			return nil, err
+		}
+
+		allProjects = append(allProjects, projects...)
+		url = nextURL
+	}
+
+	return allProjects, nil
 }
 
 func (sc *SentryClient) GetTeamsProjects(organizationSlug string, teamSlug string) ([]SentryProject, error) {

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/build"
+	"github.com/peterhellberg/link"	
 )
 
 type SentryClient struct {
@@ -32,6 +33,44 @@ func NewSentryClient(baseURL string, orgSlug string, authToken string, doerClien
 
 type SentryErrorResponse struct {
 	Detail string `json:"detail"`
+}
+
+func (sc *SentryClient) FetchWithPagination(path string, out interface{}) (string, error) {
+	fullURL := path
+	if !strings.HasPrefix(path, sc.BaseURL) {
+		fullURL = sc.BaseURL + path
+	}	
+	req, _ := http.NewRequest(http.MethodGet, fullURL, nil)
+	res, err := sc.sentryHttpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	nextURL := ""
+	header := res.Header
+	links := link.ParseHeader(header)
+
+	if links != nil {
+		if nextLink, found := links["next"]; found && nextLink.Extra["results"] == "true" {
+			nextURL = nextLink.URI
+		}
+	}
+
+	if res.StatusCode == http.StatusOK {
+		if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+			return "", err
+		}
+	} else {
+		var errResponse SentryErrorResponse
+		if err := json.NewDecoder(res.Body).Decode(&errResponse); err != nil {
+			errorMessage := strings.TrimSpace(fmt.Sprintf("%s %s", res.Status, err.Error()))
+			return "", errors.New(errorMessage)
+		}
+		errorMessage := strings.TrimSpace(fmt.Sprintf("%s %s", res.Status, errResponse.Detail))
+		return "", errors.New(errorMessage)
+	}
+	return nextURL, nil
 }
 
 func (sc *SentryClient) Fetch(path string, out interface{}) error {


### PR DESCRIPTION
### Overview

This PR introduces pagination support, enhancing our ability to retrieve data from Sentry's API efficiently.

Sentry Projects Endpoint - https://docs.sentry.io/api/organizations/list-an-organizations-projects/
Sentry Pagination Docs - https://docs.sentry.io/api/pagination/
Link Header - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link

### Changes Made

Added a new `FetchWithPagination` method in the SentryClient to parse the Link header and extract the next page URL when available, aligning our code with Sentry's pagination guidelines.

Added a new `GetAllProjects` function to utilise the enhanced Fetch method, enabling it to fetch projects across multiple pages as needed.