### PR TITLE
Grafana: support of Sentry events

### DIFF
--- a/pkg/plugin/handlers_query.go
+++ b/pkg/plugin/handlers_query.go
@@ -16,6 +16,9 @@ type SentryQuery struct {
 	IssuesQuery   string   `json:"issuesQuery,omitempty"`
 	IssuesSort    string   `json:"issuesSort,omitempty"`
 	IssuesLimit   int64    `json:"issuesLimit,omitempty"`
+	EventsQuery   string   `json:"eventsQuery,omitempty"`
+	EventsSort    string   `json:"eventsSort,omitempty"`
+	EventsLimit   int64    `json:"eventsLimit,omitempty"`
 	StatsCategory []string `json:"statsCategory,omitempty"`
 	StatsFields   []string `json:"statsFields,omitempty"`
 	StatsGroupBy  []string `json:"statsGroupBy,omitempty"`
@@ -68,6 +71,29 @@ func QueryData(ctx context.Context, pCtx backend.PluginContext, backendQuery bac
 			return GetErrorResponse(response, executedQueryString, err)
 		}
 		frame, err := framestruct.ToDataFrame(GetFrameName("Issues", backendQuery.RefID), issues)
+		if err != nil {
+			return GetErrorResponse(response, executedQueryString, err)
+		}
+		frame = UpdateFrameMeta(frame, executedQueryString, query, client.BaseURL, client.OrgSlug)
+		response.Frames = append(response.Frames, frame)
+	case "events":
+		if client.OrgSlug == "" {
+			return GetErrorResponse(response, "", ErrorInvalidOrganizationSlug)
+		}
+		events, executedQueryString, err := client.GetEvents(sentry.GetEventsInput{
+			OrganizationSlug: client.OrgSlug,
+			ProjectIds:       query.ProjectIds,
+			Environments:     query.Environments,
+			Query:            query.EventsQuery,
+			Sort:             query.EventsSort,
+			Limit:            query.EventsLimit,
+			From:             backendQuery.TimeRange.From,
+			To:               backendQuery.TimeRange.To,
+		})
+		if err != nil {
+			return GetErrorResponse(response, executedQueryString, err)
+		}
+		frame, err := framestruct.ToDataFrame(GetFrameName("Events", backendQuery.RefID), events)
 		if err != nil {
 			return GetErrorResponse(response, executedQueryString, err)
 		}

--- a/pkg/plugin/handlers_query_response.go
+++ b/pkg/plugin/handlers_query_response.go
@@ -32,7 +32,7 @@ func UpdateFrameMeta(frame *data.Frame, executedQueryString string, query Sentry
 				Links: []data.DataLink{
 					{
 						Title:       "Open in Sentry",
-						URL:         fmt.Sprintf("https://%s.sentry.io/discover/${__data.fields[\"Project\"]}:${__data.fields[\"ID\"]}/",orgSlug),
+						URL:         fmt.Sprintf("https://%s.sentry.io/discover/${__data.fields[\"Project\"]}:${__data.fields[\"ID\"]}/", orgSlug),
 						TargetBlank: true,
 					},
 				},

--- a/pkg/plugin/handlers_query_response.go
+++ b/pkg/plugin/handlers_query_response.go
@@ -27,6 +27,17 @@ func UpdateFrameMeta(frame *data.Frame, executedQueryString string, query Sentry
 				},
 			}
 		}
+		if frame.Fields[i].Name == "ID" && query.QueryType == "events" {
+			frame.Fields[i].Config = &data.FieldConfig{
+				Links: []data.DataLink{
+					{
+						Title:       "Open in Sentry",
+						URL:         fmt.Sprintf("https://%s.sentry.io/discover/${__data.fields[\"Project\"]}:${__data.fields[\"ID\"]}/",orgSlug),
+						TargetBlank: true,
+					},
+				},
+			}
+		}
 	}
 	return frame
 }

--- a/pkg/sentry/events.go
+++ b/pkg/sentry/events.go
@@ -53,34 +53,34 @@ type GetEventsInput struct {
 	Limit            int64
 }
 
-func (gii *GetEventsInput) ToQuery() string {
-	urlPath := fmt.Sprintf("/api/0/organizations/%s/events/?", gii.OrganizationSlug)
-	if gii.Limit < 1 || gii.Limit > 100 {
-		gii.Limit = 100
+func (gei *GetEventsInput) ToQuery() string {
+	urlPath := fmt.Sprintf("/api/0/organizations/%s/events/?", gei.OrganizationSlug)
+	if gei.Limit < 1 || gei.Limit > 100 {
+		gei.Limit = 100
 	}
 	params := url.Values{}
-	params.Set("query", gii.Query)
-	params.Set("start", gii.From.Format("2006-01-02T15:04:05"))
-	params.Set("end", gii.To.Format("2006-01-02T15:04:05"))
-	if gii.Sort != "" {
-		params.Set("sort", gii.Sort)
+	params.Set("query", gei.Query)
+	params.Set("start", gei.From.Format("2006-01-02T15:04:05"))
+	params.Set("end", gei.To.Format("2006-01-02T15:04:05"))
+	if gei.Sort != "" {
+		params.Set("sort", gei.Sort)
 	}
-	params.Set("per_page", strconv.FormatInt(gii.Limit, 10))
+	params.Set("per_page", strconv.FormatInt(gei.Limit, 10))
 	for _, field := range reqFields {
 		params.Add("field", field)
 	}
-	for _, projectId := range gii.ProjectIds {
+	for _, projectId := range gei.ProjectIds {
 		params.Add("project", projectId)
 	}
-	for _, environment := range gii.Environments {
+	for _, environment := range gei.Environments {
 		params.Add("environment", environment)
 	}
 	return urlPath + params.Encode()
 }
 
-func (sc *SentryClient) GetEvents(gii GetEventsInput) ([]SentryEvent, string, error) {
+func (sc *SentryClient) GetEvents(gei GetEventsInput) ([]SentryEvent, string, error) {
 	var out SentryEvents
-	executedQueryString := gii.ToQuery()
+	executedQueryString := gei.ToQuery()
 	err := sc.Fetch(executedQueryString, &out)
 	return out.Data, sc.BaseURL + executedQueryString, err
 }

--- a/pkg/sentry/events.go
+++ b/pkg/sentry/events.go
@@ -1,0 +1,86 @@
+package sentry
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+var reqFields = [...]string{
+	"id",
+	"title",
+	"project",
+	"project.id",
+	"release",
+	"count()",
+	"epm()",
+	"last_seen()",
+	"failure_rate()",
+	"level",
+	"event.type",
+	"platform",
+}
+
+type SentryEvents struct {
+	Data []SentryEvent          `json:"data"`
+	Meta map[string]interface{} `json:"meta"`
+}
+
+type SentryEvent struct {
+	ID              string    `json:"id"`
+	Title           string    `json:"title"`
+	Project         string    `json:"project"`
+	ProjectId       int64     `json:"project.id"`
+	Release         string    `json:"release"`
+	Count           int64     `json:"count()"`
+	EventsPerMinute float64   `json:"epm()"`
+	LastSeen        time.Time `json:"last_seen()"`
+	FailureRate     float64   `json:"failure_rate()"`
+	Level           string    `json:"level"`
+	EventType       string    `json:"event.type"`
+	Platform        string    `json:"platform"`
+}
+
+type GetEventsInput struct {
+	OrganizationSlug string
+	ProjectIds       []string
+	Environments     []string
+	Query            string
+	From             time.Time
+	To               time.Time
+	Sort             string
+	Limit            int64
+}
+
+func (gii *GetEventsInput) ToQuery() string {
+	urlPath := fmt.Sprintf("/api/0/organizations/%s/events/?", gii.OrganizationSlug)
+	if gii.Limit < 1 || gii.Limit > 100 {
+		gii.Limit = 100
+	}
+	params := url.Values{}
+	params.Set("query", gii.Query)
+	params.Set("start", gii.From.Format("2006-01-02T15:04:05"))
+	params.Set("end", gii.To.Format("2006-01-02T15:04:05"))
+	if gii.Sort != "" {
+		params.Set("sort", gii.Sort)
+	}
+	params.Set("per_page", strconv.FormatInt(gii.Limit, 10))
+	for _, field := range reqFields {
+		params.Add("field", field)
+	}
+	for _, projectId := range gii.ProjectIds {
+		params.Add("project", projectId)
+	}
+	for _, environment := range gii.Environments {
+		params.Add("environment", environment)
+	}
+	return urlPath + params.Encode()
+}
+
+func (sc *SentryClient) GetEvents(gii GetEventsInput) ([]SentryEvent, string, error) {
+	var out SentryEvents
+	executedQueryString := gii.ToQuery()
+	err := sc.Fetch(executedQueryString, &out)
+	return out.Data, sc.BaseURL + executedQueryString, err
+}

--- a/src/app/replace.ts
+++ b/src/app/replace.ts
@@ -26,6 +26,12 @@ export const applyTemplateVariables = (query: SentryQuery, scopedVars: ScopedVar
         projectIds: interpolateVariableArray(query.projectIds, scopedVars),
         environments: interpolateVariableArray(query.environments, scopedVars),
       };
+    case 'events':
+      return {
+        ...query,
+        projectIds: interpolateVariableArray(query.projectIds, scopedVars),
+        environments: interpolateVariableArray(query.environments, scopedVars),
+      };
     case 'statsV2':
       return {
         ...query,

--- a/src/components/query-editor/EventsEditor.spec.tsx
+++ b/src/components/query-editor/EventsEditor.spec.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { EventsEditor } from './EventsEditor';
+import type { SentryQuery } from '../../types';
+
+describe('EventsEditor', () => {
+  it('should render without error', () => {
+    const query = { queryType: 'events' } as SentryQuery;
+    const onChange = jest.fn();
+    const onRunQuery = jest.fn();
+    const result = render(<EventsEditor query={query} onChange={onChange} onRunQuery={onRunQuery} />);
+    expect(result.container.firstChild).not.toBeNull();
+  });
+});

--- a/src/components/query-editor/EventsEditor.tsx
+++ b/src/components/query-editor/EventsEditor.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { InlineFormLabel, Input, Select } from '@grafana/ui';
+import { SentryDataSource } from '../../datasource';
+import { selectors } from '../../selectors';
+import { SentryEventSortOptions } from '../../constants';
+import type { QueryEditorProps } from '@grafana/data';
+import type { SentryConfig, SentryQuery, SentryEventSort } from '../../types';
+
+type EventsEditorProps = Pick<QueryEditorProps<SentryDataSource, SentryQuery, SentryConfig>, 'query' | 'onChange' | 'onRunQuery'>;
+
+export const EventsEditor = ({ query, onChange, onRunQuery }: EventsEditorProps) => {
+  const onEventsQueryChange = (eventsQuery: string) => {
+    onChange({ ...query, eventsQuery } as SentryQuery);
+  };
+  const onEventsSortChange = (eventsSort: SentryEventSort) => {
+    onChange({ ...query, eventsSort: eventsSort || undefined } as SentryQuery);
+    onRunQuery();
+  };
+  const onEventsLimitChange = (eventsLimit?: number) => {
+    onChange({ ...query, eventsLimit: eventsLimit || undefined } as SentryQuery);
+  };
+  return query.queryType === 'events' ? (
+    <>
+      <div className="gf-form">
+        <InlineFormLabel width={10} className="query-keyword" tooltip={selectors.components.QueryEditor.Events.Query.tooltip}>
+          {selectors.components.QueryEditor.Events.Query.label}
+        </InlineFormLabel>
+        <Input
+          value={query.eventsQuery}
+          onChange={(e) => onEventsQueryChange(e.currentTarget.value)}
+          onBlur={onRunQuery}
+          placeholder={selectors.components.QueryEditor.Events.Query.placeholder}
+        />
+      </div>
+      <div className="gf-form">
+        <InlineFormLabel width={10} className="query-keyword" tooltip={selectors.components.QueryEditor.Events.Sort.tooltip}>
+          {selectors.components.QueryEditor.Events.Sort.label}
+        </InlineFormLabel>
+        <Select
+          options={SentryEventSortOptions}
+          value={query.eventsSort}
+          width={28}
+          onChange={(e) => onEventsSortChange(e?.value!)}
+          className="inline-element"
+          placeholder={selectors.components.QueryEditor.Events.Sort.placeholder}
+          isClearable={true}
+        />
+        <InlineFormLabel width={8} className="query-keyword" tooltip={selectors.components.QueryEditor.Events.Limit.tooltip}>
+          {selectors.components.QueryEditor.Events.Limit.label}
+        </InlineFormLabel>
+        <Input
+          value={query.eventsLimit}
+          type="number"
+          onChange={(e) => onEventsLimitChange(e.currentTarget.valueAsNumber)}
+          onBlur={onRunQuery}
+          width={32}
+          className="inline-element"
+          placeholder={selectors.components.QueryEditor.Events.Limit.placeholder}
+        />
+      </div>
+    </>
+  ) : (
+    <></>
+  );
+};

--- a/src/components/query-editor/EventsEditor.tsx
+++ b/src/components/query-editor/EventsEditor.tsx
@@ -13,11 +13,11 @@ export const EventsEditor = ({ query, onChange, onRunQuery }: EventsEditorProps)
     onChange({ ...query, eventsQuery } as SentryQuery);
   };
   const onEventsSortChange = (eventsSort: SentryEventSort) => {
-    onChange({ ...query, eventsSort: eventsSort || undefined } as SentryQuery);
+    onChange({ ...query, eventsSort } as SentryQuery);
     onRunQuery();
   };
   const onEventsLimitChange = (eventsLimit?: number) => {
-    onChange({ ...query, eventsLimit: eventsLimit || undefined } as SentryQuery);
+    onChange({ ...query, eventsLimit } as SentryQuery);
   };
   return query.queryType === 'events' ? (
     <>

--- a/src/components/query-editor/ScopePicker.tsx
+++ b/src/components/query-editor/ScopePicker.tsx
@@ -16,7 +16,7 @@ type ScopePickerProps = { hideEnvironments?: boolean } & Pick<
 export const ScopePicker = (props: ScopePickerProps) => {
   const { query, onChange, onRunQuery, datasource, hideEnvironments = false } = props;
   const { projectIds } = query;
-  const environments = query.queryType === 'issues' ? query.environments : [];
+  const environments = query.queryType === 'issues' || query.queryType === 'events' ? query.environments : [];
   const [projects, setProjects] = useState<SentryProject[]>([]);
   const [allEnvironments, setAllEnvironments] = useState<string[]>([]);
   const orgSlug = datasource.getOrgSlug();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,7 +23,6 @@ export const SentryIssueSortOptions: Array<SelectableValue<SentryIssueSort>> = [
   { value: 'user', label: 'Users' },
 ];
 export const SentryEventSortOptions: Array<SelectableValue<SentryEventSort>> = [
-  // { value: 'inbox', label: 'Date Added' },
   { value: 'last_seen()', label: 'Last Seen' },
   { value: 'count()', label: 'Count' },
   { value: 'epm()', label: 'Events per minute' },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@ import type { SelectableValue } from '@grafana/data';
 import type {
   QueryType,
   SentryIssueSort,
+  SentryEventSort,
   SentryStatsV2QueryField,
   SentryStatsV2QueryGroupBy,
   SentryStatsV2QueryCategory,
@@ -10,6 +11,7 @@ import type {
 
 export const QueryTypeOptions: Array<SelectableValue<QueryType>> = [
   { value: 'issues', label: 'Issues' },
+  { value: 'events', label: 'Events' },
   { value: 'statsV2', label: 'Stats' },
 ];
 export const SentryIssueSortOptions: Array<SelectableValue<SentryIssueSort>> = [
@@ -19,6 +21,14 @@ export const SentryIssueSortOptions: Array<SelectableValue<SentryIssueSort>> = [
   { value: 'priority', label: 'Priority' },
   { value: 'freq', label: 'Events' },
   { value: 'user', label: 'Users' },
+];
+export const SentryEventSortOptions: Array<SelectableValue<SentryEventSort>> = [
+  // { value: 'inbox', label: 'Date Added' },
+  { value: 'last_seen()', label: 'Last Seen' },
+  { value: 'count()', label: 'Count' },
+  { value: 'epm()', label: 'Events per minute' },
+  { value: 'failure_rate()', label: 'Failure rate' },
+  { value: 'level', label: 'Level' },
 ];
 export const SentryStatsV2QueryFieldOptions: Array<SelectableValue<SentryStatsV2QueryField>> = [
   { value: 'sum(quantity)', label: 'sum(quantity)' },

--- a/src/editors/SentryQueryEditor.tsx
+++ b/src/editors/SentryQueryEditor.tsx
@@ -4,6 +4,7 @@ import { Error } from '../components/Error';
 import { QueryTypePicker } from './../components/query-editor/QueryTypePicker';
 import { ScopePicker } from './../components/query-editor/ScopePicker';
 import { IssuesEditor } from './../components/query-editor/IssuesEditor';
+import { EventsEditor } from './../components/query-editor/EventsEditor';
 import { StatsV2Editor } from './../components/query-editor/StatsV2Editor';
 import type { QueryEditorProps } from '@grafana/data';
 import type { SentryConfig, SentryQuery } from './../types';
@@ -24,6 +25,7 @@ export const SentryQueryEditor = (props: SentryQueryEditorProps) => {
       <QueryTypePicker {...props} />
       <ScopePicker {...props} hideEnvironments={query.queryType === 'statsV2'} />
       {query.queryType === 'issues' ? <IssuesEditor {...props} /> : null}
+      {query.queryType === 'events' ? <EventsEditor {...props} /> : null}
       {query.queryType === 'statsV2' ? <StatsV2Editor {...props} /> : null}
     </div>
   );

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -68,6 +68,23 @@ export const Components = {
         placeholder: '100',
       },
     },
+    Events: {
+      Query: {
+        label: 'Query',
+        tooltip: 'Sentry query to filter the results, details https://docs.sentry.io/product/sentry-basics/search/',
+        placeholder: 'is:unresolved',
+      },
+      Sort: {
+        label: 'Sort By',
+        tooltip: 'Sort results',
+        placeholder: 'Optional',
+      },
+      Limit: {
+        label: 'Limit',
+        tooltip: 'Number of results (100 max)',
+        placeholder: '100',
+      },
+    },
     StatsV2: {
       Field: {
         label: 'Field',

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export type SentryTeam = {
   status?: string;
 };
 export type SentryIssueSort = 'inbox' | 'new' | 'date' | 'priority' | 'freq' | 'user';
+export type SentryEventSort = 'last_seen()' | 'count()' | 'epm()' | 'failure_rate()' | 'level';
 //#endregion
 
 //#region Config
@@ -51,7 +52,7 @@ export interface SentrySecureConfig {
 //#endregion
 
 //#region Query
-export type QueryType = 'issues' | 'statsV2';
+export type QueryType = 'issues' | 'events' | 'statsV2';
 export type SentryQueryBase<T extends QueryType> = { queryType: T } & DataQuery;
 export type SentryIssuesQuery = {
   projectIds: string[];
@@ -60,6 +61,13 @@ export type SentryIssuesQuery = {
   issuesSort?: SentryIssueSort;
   issuesLimit?: number;
 } & SentryQueryBase<'issues'>;
+export type SentryEventsQuery = {
+  projectIds: string[];
+  environments: string[];
+  eventsQuery: string;
+  eventsSort?: SentryEventSort;
+  eventsLimit?: number;
+} & SentryQueryBase<'events'>;
 export type SentryStatsV2QueryField = 'sum(quantity)' | 'sum(times_seen)';
 export type SentryStatsV2QueryGroupBy = 'outcome' | 'reason' | 'category';
 export type SentryStatsV2QueryCategory = 'transaction' | 'error' | 'attachment' | 'default' | 'session' | 'security';
@@ -72,7 +80,7 @@ export type SentryStatsV2Query = {
   statsOutcome: SentryStatsV2QueryOutcome[];
   statsReason: string[];
 } & SentryQueryBase<'statsV2'>;
-export type SentryQuery = SentryIssuesQuery | SentryStatsV2Query;
+export type SentryQuery = SentryIssuesQuery | SentryEventsQuery | SentryStatsV2Query;
 //#endregion
 
 //#region Variable Query


### PR DESCRIPTION
This pull request introduces support for Sentry Events into the Sentry plugin for Grafana. Users can now seamlessly monitor and analyse Sentry events within Grafana.

![image](https://github.com/Canva/grafana-sentry-datasource/assets/20262077/e1ec0ab4-bc7e-41a3-bd96-98ecc6c22dc0)

In addition, a user can filter, query and sort results using provided fields.

![image](https://github.com/Canva/grafana-sentry-datasource/assets/20262077/c6b65e98-a844-4960-8423-77ccfb0eef22)
