### PR TITLE
Support for project slugs, caching results

### DIFF
--- a/pkg/plugin/handlers_healthcheck.go
+++ b/pkg/plugin/handlers_healthcheck.go
@@ -20,7 +20,7 @@ func (ds *SentryDatasource) CheckHealth(ctx context.Context, req *backend.CheckH
 }
 
 func CheckHealth(sentryClient sentry.SentryClient) (*backend.CheckHealthResult, error) {
-	projects, err := sentryClient.GetProjects(sentryClient.OrgSlug, false)
+	projects, err := sentryClient.GetProjects(sentryClient.OrgSlug, false, true)
 	if err != nil {
 		errorMessage := err.Error()
 		return &backend.CheckHealthResult{

--- a/pkg/plugin/handlers_query.go
+++ b/pkg/plugin/handlers_query.go
@@ -49,7 +49,7 @@ func (ds *SentryDatasource) QueryData(ctx context.Context, req *backend.QueryDat
 
 // Convert project slugs to project IDs (if there are any)
 func ConvertProjectSlugsToIDs(ctx context.Context, client sentry.SentryClient, query *SentryQuery) {
-	slugsToReplace := make([]string, 0)
+	slugsToReplace := make([]string, 0, len(query.ProjectIds))
 
 	for _, idOrSlug := range query.ProjectIds {
 		if _, err := strconv.Atoi(idOrSlug); err != nil {

--- a/pkg/plugin/handlers_resources.go
+++ b/pkg/plugin/handlers_resources.go
@@ -33,7 +33,7 @@ func GetProjectsHandler(client *sentry.SentryClient) http.HandlerFunc {
 			http.Error(rw, "invalid orgSlug", http.StatusBadRequest)
 			return
 		}
-		orgs, err := client.GetProjects(orgSlug, true)
+		orgs, err := client.GetProjects(orgSlug, true, false)
 		writeResponse(orgs, err, rw)
 	}
 }

--- a/pkg/sentry/cache.go
+++ b/pkg/sentry/cache.go
@@ -1,0 +1,46 @@
+package sentry
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	defaultCacheTTL = 5 * time.Minute
+)
+
+type Cache struct {
+	mu         sync.Mutex
+	data       map[string]interface{}
+	expiration map[string]time.Time
+}
+
+func NewCache() *Cache {
+	return &Cache{
+		data:       make(map[string]interface{}),
+		expiration: make(map[string]time.Time),
+	}
+}
+
+func (c *Cache) Set(key string, value interface{}, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data[key] = value
+	c.expiration[key] = time.Now().Add(ttl)
+}
+
+func (c *Cache) Get(key string) (interface{}, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	value, found := c.data[key]
+	if !found {
+		return nil, false
+	}
+	expTime, expFound := c.expiration[key]
+	if !expFound || time.Now().After(expTime) {
+		delete(c.data, key)
+		delete(c.expiration, key)
+		return nil, false
+	}
+	return value, true
+}

--- a/pkg/sentry/cache.go
+++ b/pkg/sentry/cache.go
@@ -9,27 +9,27 @@ const (
 	defaultCacheTTL = 5 * time.Minute
 )
 
-type Cache struct {
+type Cache[T comparable] struct {
 	mu         sync.Mutex
-	data       map[string]interface{}
+	data       map[string]T
 	expiration map[string]time.Time
 }
 
-func NewCache() *Cache {
+func NewCache[T comparable]() *Cache {
 	return &Cache{
-		data:       make(map[string]interface{}),
+		data:       make(map[string]T),
 		expiration: make(map[string]time.Time),
 	}
 }
 
-func (c *Cache) Set(key string, value interface{}, ttl time.Duration) {
+func (c *Cache) Set[T comparable](key string, value T, ttl time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.data[key] = value
 	c.expiration[key] = time.Now().Add(ttl)
 }
 
-func (c *Cache) Get(key string) (interface{}, bool) {
+func (c *Cache) Get[T comparable](key string) (T, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	value, found := c.data[key]

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -16,6 +16,7 @@ type SentryClient struct {
 	OrgSlug          string
 	authToken        string
 	sentryHttpClient HTTPClient
+	cache            *Cache
 }
 
 func NewSentryClient(baseURL string, orgSlug string, authToken string, doerClient doer) (*SentryClient, error) {
@@ -23,6 +24,7 @@ func NewSentryClient(baseURL string, orgSlug string, authToken string, doerClien
 		BaseURL:   DefaultSentryURL,
 		OrgSlug:   orgSlug,
 		authToken: authToken,
+		cache:     NewCache(),
 	}
 	if baseURL != "" {
 		client.BaseURL = baseURL


### PR DESCRIPTION
The current implementation of Sentry plugin supports filtering issues, events, and statistics by project ID, which is specific to Sentry. This limitation poses challenges when trying to filter by project when the list of projects is sourced from a different provider, such as Datadog.

This pull request addresses this issue by introducing a solution that checks for any project slugs and replaces them with the corresponding project ID. Additionally, to optimise performance and reduce excessive calls to the Sentry API when fetching the project list, I have introduced a straightforward in-memory caching mechanism.
This caching solution is designed to be simple and efficient, but it may be replaced with a more specialised library in the future as needed.