### PR TITLE
Issues count as number data type

### DIFF
--- a/pkg/sentry/issues.go
+++ b/pkg/sentry/issues.go
@@ -11,7 +11,7 @@ type SentryIssue struct {
 	ID          string    `json:"id"`
 	ShortID     string    `json:"shortId"`
 	Title       string    `json:"title"`
-	Count       string    `json:"count"`
+	Count       int64     `json:"count"`
 	UserCount   int64     `json:"userCount"`
 	Status      string    `json:"status"`
 	Level       string    `json:"level"`


### PR DESCRIPTION
Change the data type for the `count` field from `string` to `int64`, so the rows can be sorted correctly
<img width="174" alt="image" src="https://github.com/Canva/grafana-sentry-datasource/assets/20262077/67f4554e-17a1-4cfb-9e64-f2df79783352">
